### PR TITLE
fixes for obtaining metrics

### DIFF
--- a/node_exporter_kube_state/deploy/litmus-event-router/event-router.yaml
+++ b/node_exporter_kube_state/deploy/litmus-event-router/event-router.yaml
@@ -40,6 +40,7 @@ metadata:
 spec:
   ports:
   - nodePort: 31399
+    name: web
     port: 8080
     protocol: TCP
     targetPort: 8080

--- a/node_exporter_kube_state/deploy/litmus-event-router/service-monitor.yaml
+++ b/node_exporter_kube_state/deploy/litmus-event-router/service-monitor.yaml
@@ -3,13 +3,13 @@ kind: ServiceMonitor
 metadata:
   name: litmus-event-router
   labels:
-    k8s-app: litmus-eventrouter
-  namespace: monitoring
+    k8s-app: litmus-event-router
+  namespace: litmus
 spec:
-  jobLabel: name
+  jobLabel: app
   selector:
     matchLabels:
-      name: litmus-eventrouter
+      app: litmus-eventrouter
   namespaceSelector:
     matchNames:
     - litmus

--- a/node_exporter_kube_state/deploy/prometheus-cluster-monitoring/cluster-role.yaml
+++ b/node_exporter_kube_state/deploy/prometheus-cluster-monitoring/cluster-role.yaml
@@ -4,11 +4,11 @@ metadata:
   name: prometheus-k8s
 rules:
 - apiGroups:
-  - ""
+  - "*"
   resources:
-  - nodes/metrics
+  - "*"
   verbs:
-  - get
+  - "*"
 - nonResourceURLs:
   - /metrics
   verbs:

--- a/node_exporter_kube_state/deploy/prometheus-cluster-monitoring/prometheus.yaml
+++ b/node_exporter_kube_state/deploy/prometheus-cluster-monitoring/prometheus.yaml
@@ -4,13 +4,14 @@ metadata:
   labels:
     prometheus: k8s
   name: k8s
-  namespace: litmus-monitoring
 spec:
   alerting:
     alertmanagers:
     - name: alertmanager-main
       namespace: litmus-monitoring
       port: web
+  externalLabels:
+    cluster: docker-desktop
   image: quay.io/prometheus/prometheus:v2.19.2
   nodeSelector:
     kubernetes.io/os: linux
@@ -20,18 +21,16 @@ spec:
   resources:
     requests:
       memory: 400Mi
-  externalLabels:
-    cluster: docker-desktop
-  serviceAccountName: prometheus-k8s
-  version: v2.19.2
   ruleSelector:
     matchLabels:
-      role: alert-rules
       prometheus: k8s
+      role: alert-rules
   securityContext:
     fsGroup: 2000
     runAsNonRoot: true
     runAsUser: 1000
+  serviceAccountName: prometheus-k8s
+  serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector:
     matchExpressions:
     - key: k8s-app
@@ -41,6 +40,18 @@ spec:
       - kube-state-metrics
       - apiserver
       - kubelet
-      - chaos-exporter
+      - carts
+      - carts-db
+      - shipping
+      - rabbitmq
+      - queue-master
+      - catalogue-db
+      - catalogue
+      - front-end
+      - orders-db
+      - orders
+      - payment
+      - user-db
+      - user
       - litmus-event-router
-  
+  version: v2.19.2

--- a/node_exporter_kube_state/deploy/sock-shop-service-mon/carts-db.yaml
+++ b/node_exporter_kube_state/deploy/sock-shop-service-mon/carts-db.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     name: carts-db
     k8s-app: carts-db
-  namespace: monitoring
+  namespace: sock-shop
 spec:
   jobLabel: name
   selector:

--- a/node_exporter_kube_state/deploy/sock-shop-service-mon/carts.yaml
+++ b/node_exporter_kube_state/deploy/sock-shop-service-mon/carts.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     name: carts
     k8s-app: carts
-  namespace: monitoring
+  namespace: sock-shop
 spec:
   jobLabel: name
   selector:

--- a/node_exporter_kube_state/deploy/sock-shop-service-mon/catalogue-db.yaml
+++ b/node_exporter_kube_state/deploy/sock-shop-service-mon/catalogue-db.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     name: catalogue-db
     k8s-app: catalogue-db
-  namespace: monitoring
+  namespace: sock-shop
 spec:
   jobLabel: name
   selector:

--- a/node_exporter_kube_state/deploy/sock-shop-service-mon/catalogue.yaml
+++ b/node_exporter_kube_state/deploy/sock-shop-service-mon/catalogue.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     name: catalogue
     k8s-app: catalogue
-  namespace: monitoring
+  namespace: sock-shop
 spec:
   jobLabel: name
   selector:

--- a/node_exporter_kube_state/deploy/sock-shop-service-mon/front-end.yaml
+++ b/node_exporter_kube_state/deploy/sock-shop-service-mon/front-end.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     name: front-end
     k8s-app: front-end
-  namespace: monitoring
+  namespace: sock-shop
 spec:
   jobLabel: name
   selector:

--- a/node_exporter_kube_state/deploy/sock-shop-service-mon/orders-db.yaml
+++ b/node_exporter_kube_state/deploy/sock-shop-service-mon/orders-db.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     name: front-end
     k8s-app: front-end
-  namespace: monitoring
+  namespace: sock-shop
 spec:
   jobLabel: name
   selector:

--- a/node_exporter_kube_state/deploy/sock-shop-service-mon/orders.yaml
+++ b/node_exporter_kube_state/deploy/sock-shop-service-mon/orders.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     name: orders
     k8s-app: orders
-  namespace: monitoring
+  namespace: sock-shop
 spec:
   jobLabel: name
   selector:

--- a/node_exporter_kube_state/deploy/sock-shop-service-mon/payment.yaml
+++ b/node_exporter_kube_state/deploy/sock-shop-service-mon/payment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     name: payment
     k8s-app: payment
-  namespace: monitoring
+  namespace: sock-shop
 spec:
   jobLabel: name
   selector:

--- a/node_exporter_kube_state/deploy/sock-shop-service-mon/queue-master.yaml
+++ b/node_exporter_kube_state/deploy/sock-shop-service-mon/queue-master.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     name: queue-master
     k8s-app: queue-master
-  namespace: monitoring
+  namespace: sock-shop
 spec:
   jobLabel: name
   selector:

--- a/node_exporter_kube_state/deploy/sock-shop-service-mon/rabbitmq.yaml
+++ b/node_exporter_kube_state/deploy/sock-shop-service-mon/rabbitmq.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     name: rabbitmq
     k8s-app: rabbitmq
-  namespace: monitoring
+  namespace: sock-shop
 spec:
   jobLabel: name
   selector:

--- a/node_exporter_kube_state/deploy/sock-shop-service-mon/shipping.yaml
+++ b/node_exporter_kube_state/deploy/sock-shop-service-mon/shipping.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     name: shipping
     k8s-app: shipping
-  namespace: monitoring
+  namespace: sock-shop
 spec:
   jobLabel: name
   selector:

--- a/node_exporter_kube_state/deploy/sock-shop-service-mon/user-db.yaml
+++ b/node_exporter_kube_state/deploy/sock-shop-service-mon/user-db.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     name: user-db
     k8s-app: user-db
-  namespace: monitoring
+  namespace: sock-shop
 spec:
   jobLabel: name
   selector:

--- a/node_exporter_kube_state/deploy/sock-shop-service-mon/user.yaml
+++ b/node_exporter_kube_state/deploy/sock-shop-service-mon/user.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     name: user
     k8s-app: user
-  namespace: monitoring
+  namespace: sock-shop
 spec:
   jobLabel: name
   selector:


### PR DESCRIPTION
### Changes 

- The service monitors are needed to be created in the same ns where the app service resides
- Ensure that the `prometheus` custom resource uses the attribute `spec. serviceMonitorNamespaceSelector: {}` in order to enable watch of servicemonitors across all namespaces by the operator. 
- Ensure that the serviceaccount used by the prom deployment (not operator) has the ability to scrape metrics across app namespaces (have used a `*/*/*` for time being - please reduce this as needed) 
- The `.spec.jobLabel` defined in servicemonitor CRs need to match the label key of the app service under monitor
- If the servicemonitor CR spec specifies a port name, ensure it is there on the app service too 


### TODO

- Please update the dashboards to use latest metric filters (old ones are changed) for the graphs to start showing up. 

Signed-off-by: ksatchit <karthik.s@mayadata.io>